### PR TITLE
60-keyboard: Add Pang12 config

### DIFF
--- a/debian/patches/pang12.patch
+++ b/debian/patches/pang12.patch
@@ -1,0 +1,15 @@
+Index: systemd/hwdb.d/60-keyboard.hwdb
+===================================================================
+--- systemd.orig/hwdb.d/60-keyboard.hwdb
++++ systemd/hwdb.d/60-keyboard.hwdb
+@@ -1693,6 +1693,10 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem7
+  KEYBOARD_KEY_f7=f21                                    # Touchpad toggle
+  KEYBOARD_KEY_f8=f21                                    # Touchpad toggle
+ 
++# Pangolin 12
++evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem76*:pnPangolin*:pvrpang12*
++ KEYBOARD_KEY_76=f21                                    # Touchpad toggle
++
+ ###########################################################
+ # T-bao
+ ###########################################################

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -106,3 +106,4 @@ systemd-boot-id-compat.patch
 system76-usb.patch
 hp-dev-one.patch
 timesyncd-disable.patch
+pang12.patch


### PR DESCRIPTION
Fn+F6 has a disable touchpad icon on it, but the mapping was incorrect. This fixes that.