### PR TITLE
fix: disable chrony dependency for i386

### DIFF
--- a/debian/patches/timesyncd-disable.patch
+++ b/debian/patches/timesyncd-disable.patch
@@ -8,7 +8,7 @@ Index: systemd/debian/control
           util-linux (>= 2.27.1),
           mount (>= 2.26),
           adduser,
-+         chrony,
++         chrony [!i386],
  Conflicts: consolekit,
             libpam-ck-connector,
             systemd-shim,


### PR DESCRIPTION
This should fix the build for https://github.com/pop-os/pipewire/pull/57, as it depends on `systemd`, but `chrony` packages aren't available for i386.