### PR TITLE
60-keyboard: Add pang14 config

### DIFF
--- a/debian/patches/pang14.patch
+++ b/debian/patches/pang14.patch
@@ -1,0 +1,15 @@
+Index: systemd/hwdb.d/60-keyboard.hwdb
+===================================================================
+--- systemd.orig/hwdb.d/60-keyboard.hwdb
++++ systemd/hwdb.d/60-keyboard.hwdb
+@@ -1698,0 +1698,0 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem7
+  KEYBOARD_KEY_f7=f21                                    # Touchpad toggle
+  KEYBOARD_KEY_76=f21                                    # Touchpad toggle
+
++# Pangolin 14
++evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem76*:pnPangolin*:pvrpang14*
++ KEYBOARD_KEY_76=f21                                    # Touchpad toggle
++
+ ###########################################################
+ # T-bao
+ ###########################################################

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -124,3 +124,4 @@ pang12.patch
 systemd-resolvconf.patch
 system76-micmute.patch
 pang13.patch
+pang14.patch


### PR DESCRIPTION
I referenced [pang12](https://github.com/pop-os/systemd/pull/29) and [pang13](https://github.com/pop-os/systemd/pull/40) for this. I don't understand line 6 in pang14.patch, so I left it the same as the one from pang13.